### PR TITLE
fix: fix transaction conflict then working two transfer function simultaneously

### DIFF
--- a/dev/staging_data_gen.lua
+++ b/dev/staging_data_gen.lua
@@ -1,0 +1,16 @@
+#!/usr/bin/env tarantool
+
+nb = require('net.box')
+conn = nb.connect('admin:memstorage-cluster-cookie@localhost:3304')
+
+local function datagen(space_name, number_of_rows)
+    local tuples = {}
+    for i=1,number_of_rows,1 do
+        conn.space[space_name]:replace({i,'a777a750',0,100})
+    end
+end
+
+datagen('adb__adg_test__env_test_staging', 100000)
+conn:close()
+
+-- transfer_stage_data_to_scd_table('adb__adg_test__env_test_staging', 'adb__adg_test__env_test_actual', 'adb__adg_test__env_test_history', 1)


### PR DESCRIPTION
После получения данных и Kafka вызывается callback функция (_transfer_stage_data_to_scd_table_), которая отвечает за загрузку данных из staging таблицы в остальные (actual и history). В данной функции вызывается moonwolker который стартует сам процесс перекладки для каждой записи и работает в фоне. 

После этого функция _transfer_stage_data_to_scd_table_  запускается еще раз в явном виде через обращение к API и делает тоже самое.

В результате получается что два moonwolker процесса начинают переваривать один и те же данные с одними и теми же спейсами что в итоге приводит к ошибке "Transaction has been aborted by conflict". 

Чтобы это исправить **был добавлен мьютекс** который не позволит запустить функцию **transfer_stage_data_to_scd_table** более одного раза одновременно.