### PR TITLE
fix: enable and fix JSON-parsing tests

### DIFF
--- a/test/unit/app/utils/bin_avro_utils_test.lua
+++ b/test/unit/app/utils/bin_avro_utils_test.lua
@@ -83,89 +83,90 @@ g2.test_topicX_transformation = function ()
     t.assert_equals(decoded_value,bin_avro_utils.clean_table_of_records_from_avro_types(values))
 end
 
-g2.test_transformation_with_external_schema = function()
-    local value_schema,_ = file_utils.read_file('test/unit/data/avro_schemas/topicZ_avro_schema_value.json')
-    local encoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded.avro')
-    local decoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded.json')
+-- DEPRECATED TEST FOR AVRO SCHEME
+-- g2.test_transformation_with_external_schema = function()
+--     local value_schema,_ = file_utils.read_file('test/unit/data/avro_schemas/topicZ_avro_schema_value.json')
+--     local encoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded.avro')
+--     local decoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded.json')
 
-    local ok1,decoded_value1 = bin_avro_utils.decode(encoded1, value_schema)
-
-    t.assert_equals(ok1,true)
-    t.assert_equals(decoded_value1,json.decode(decoded1))
-
-    local encoded2,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded3.avro')
-    local decoded2,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded2.json')
-
-    local ok2,decoded_value2 = bin_avro_utils.decode(encoded2,value_schema)
-
-    t.assert_equals(ok2,true)
-    t.assert_equals(decoded_value2,json.decode(decoded2))
-
-    local encoded3,_ = file_utils.read_file('test/unit/data/avro_values/test1_value_encoded.avro')
-    local decoded3,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
-
-    local ok3,decoded_value3 = bin_avro_utils.decode(encoded3,value_schema)
-
-    t.assert_equals(ok3,true)
-    t.assert_equals(decoded_value3,json.decode(decoded3))
-end
-
--- g2.test_transformation_with_schema_in_data = function()
---     local encoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded2.avro')
---     local decoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded2.json')
---     local ok1, decoded_value1 = bin_avro_utils.decode(encoded1)
+--     local ok1,decoded_value1 = bin_avro_utils.decode(encoded1, value_schema)
 
 --     t.assert_equals(ok1,true)
 --     t.assert_equals(decoded_value1,json.decode(decoded1))
 
+--     local encoded2,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded3.avro')
+--     local decoded2,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded2.json')
 
---     local encoded2,_ = file_utils.read_file('test/unit/data/avro_values/test2_value_encoded.avro')
---     local decoded2,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
---     local ok2, decoded_value2= bin_avro_utils.decode(encoded2)
+--     local ok2,decoded_value2 = bin_avro_utils.decode(encoded2,value_schema)
 
 --     t.assert_equals(ok2,true)
 --     t.assert_equals(decoded_value2,json.decode(decoded2))
 
-
---     local encoded3,_ = file_utils.read_file('test/unit/data/avro_values/test2_value_encoded.avro')
+--     local encoded3,_ = file_utils.read_file('test/unit/data/avro_values/test1_value_encoded.avro')
 --     local decoded3,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
---     local ok3, decoded_value3= bin_avro_utils.decode(encoded3)
+
+--     local ok3,decoded_value3 = bin_avro_utils.decode(encoded3,value_schema)
 
 --     t.assert_equals(ok3,true)
 --     t.assert_equals(decoded_value3,json.decode(decoded3))
-
---     local encoded4,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded2.avro')
---     local decoded4,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded2.json')
---     local ok4, decoded_value4 = bin_avro_utils.decode(encoded4)
-
---     t.assert_equals(ok4,true)
---     t.assert_equals(decoded_value4,json.decode(decoded4))
-
-
 -- end
 
--- g2.test_transformation_with_schema2_in_data = function()
---     local encoded,_ = file_utils.read_file('test/unit/data/avro_values/test3_value_encoded.avro')
---     local decoded,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
+g2.test_transformation_with_schema_in_data = function()
+    local encoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded2.avro')
+    local decoded1,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded2.json')
+    local ok1, decoded_value1 = bin_avro_utils.decode(encoded1)
 
---     local ok, decoded_value= bin_avro_utils.decode(encoded)
+    t.assert_equals(ok1,true)
+    t.assert_equals(decoded_value1,json.decode(decoded1))
 
---     t.assert_equals(ok,true)
---     t.assert_equals(decoded_value,json.decode(decoded))
--- end
 
--- g2.test_transformation_with_schema2_in_data_fast = function()
---     local encoded,_ = file_utils.read_file('test/unit/data/avro_values/test3_value_encoded.avro')
---     local decoded,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
+    local encoded2,_ = file_utils.read_file('test/unit/data/avro_values/test2_value_encoded.avro')
+    local decoded2,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
+    local ok2, decoded_value2= bin_avro_utils.decode(encoded2)
 
---     local ok, decoded_value= bin_avro_utils.decode(encoded)
+    t.assert_equals(ok2,true)
+    t.assert_equals(decoded_value2,json.decode(decoded2))
 
---     t.assert_equals(ok,true)
---     t.assert_equals(decoded_value,json.decode(decoded))
--- end
 
+    local encoded3,_ = file_utils.read_file('test/unit/data/avro_values/test2_value_encoded.avro')
+    local decoded3,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
+    local ok3, decoded_value3= bin_avro_utils.decode(encoded3)
+
+    t.assert_equals(ok3,true)
+    t.assert_equals(decoded_value3,json.decode(decoded3))
+
+    local encoded4,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_encoded2.avro')
+    local decoded4,_ = file_utils.read_file('test/unit/data/avro_values/topicZ_value_decoded2.json')
+    local ok4, decoded_value4 = bin_avro_utils.decode(encoded4)
+
+    t.assert_equals(ok4,true)
+    t.assert_equals(decoded_value4,json.decode(decoded4))
+
+
+end
+
+g2.test_transformation_with_schema2_in_data = function()
+    local encoded,_ = file_utils.read_file('test/unit/data/avro_values/test3_value_encoded.avro')
+    local decoded,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
+
+    local ok, decoded_value= bin_avro_utils.decode(encoded)
+
+    t.assert_equals(ok,true)
+    t.assert_equals(decoded_value,json.decode(decoded))
+end
+
+g2.test_transformation_with_schema2_in_data_fast = function()
+    local encoded,_ = file_utils.read_file('test/unit/data/avro_values/test3_value_encoded.avro')
+    local decoded,_ = file_utils.read_file('test/unit/data/avro_values/test1_2_value_decoded.json')
+
+    local ok, decoded_value= bin_avro_utils.decode(encoded)
+
+    t.assert_equals(ok,true)
+    t.assert_equals(decoded_value,json.decode(decoded))
+end
+
+-- DEPRECATED TEST FOR AVRO SCHEME
 -- g2.test_large_encode_decode = function()
-
 
 --     local encoded = file_utils.read_file('test/unit/data/avro_values/avro1000_000_w_s.avro')
 --     local schema_ok, schema = bin_avro_utils.extract_metadata(encoded)
@@ -173,7 +174,6 @@ end
 --     t.assert_equals(schema_ok,true)
 
 --     local json_value = json.decode(file_utils.read_file('test/unit/data/avro_values/avro1000_000.json'))
-
 --     local ok2,res2 = bin_avro_utils.encode(schema.value['avro.schema'],json_value,true)
 
 --     t.assert_equals(ok2,true)
@@ -181,28 +181,14 @@ end
 --     local ok3,res3 = bin_avro_utils.decode(res2)
 
 --     t.assert_equals(ok3,true)
-
 --     t.assert_equals(#res3,#json_value)
-
 
 --     local ok4,res4 = bin_avro_utils.decode(encoded)
 
 --     t.assert_equals(ok4,true)
-
 --     t.assert_equals(1000000,#res4)
 
 -- end
-
-local function test_decoding_perf_avro_object_container(file,row_cnt,run_cnt)
-    local start_time = os.clock()
-    local encoded,_ = file_utils.read_file(file)
-    for _=1,run_cnt,1 do
-        local ok, _= bin_avro_utils.decode(encoded)
-        t.assert_equals(ok,true)
-    end
-    local end_time = os.clock()
-    return end_time - start_time < row_cnt * run_cnt / 59000
-end
 
 local function test_decoding_avro_single_object(run_cnt)
     local start_time = os.clock()
@@ -221,6 +207,18 @@ local function test_decoding_avro_single_object(run_cnt)
     local end_time = os.clock()
     return end_time - start_time <  run_cnt * 0.1
 end
+
+-- DEPRECATED TEST FOR AVRO SCHEME
+-- local function test_decoding_perf_avro_object_container(file,row_cnt,run_cnt)
+--     local start_time = os.clock()
+--     local encoded,_ = file_utils.read_file(file)
+--     for _=1,run_cnt,1 do
+--         local ok, _= bin_avro_utils.decode(encoded)
+--         t.assert_equals(ok,true)
+--     end
+--     local end_time = os.clock()
+--     return end_time - start_time < row_cnt * run_cnt / 59000
+-- end
 
 -- g3.test_perf_decoding_file_with_schema = function()
 --     t.assert_equals(test_decoding_perf_avro_object_container('test/unit/data/avro_values/avro1000.avro',1000,100), true)

--- a/test/unit/data/avro_values/test1_2_value_decoded.json
+++ b/test/unit/data/avro_values/test1_2_value_decoded.json
@@ -1,12 +1,12 @@
 [
-  {"f1":  null,"f2":  null, "f3":  null},
-  {"f1":  null,"f2":  null, "f3":  null},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"}
+  [null, null, null],
+  [null, null, null],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"],
+  ["test_1", null, "test_2"]
 ]

--- a/test/unit/data/avro_values/topicZ_value_decoded2.json
+++ b/test/unit/data/avro_values/topicZ_value_decoded2.json
@@ -1,5 +1,5 @@
 [
-  {"f1":  null,"f2":  null, "f3":  null},
-  {"f1":  null,"f2":  null, "f3":  null},
-  {"f1":  "test_1","f2":  null, "f3":  "test_2"}
+  [null, null, null],
+  [null, null, null],
+  ["test_1", null, "test_2"]
 ]


### PR DESCRIPTION
Structure dict-in-array changed to array-in-array for JSON

Enables tests:
- test_transformation_with_schema2_in_data
- test_transformation_with_schema2_in_data_fast
Still disabled tests:
- test_large_encode_decode
- test_perf_decoding_file_with_schema